### PR TITLE
Viewhash moreinfo

### DIFF
--- a/docs/reference/classes/requesthandlers-api.md
+++ b/docs/reference/classes/requesthandlers-api.md
@@ -2432,19 +2432,19 @@ static · Returns `string`
 
 ### Methods
 
-#### [`__construct`](../../../src/RequestHandlers/Api/HistoryView.php#L50-L57)
+#### [`__construct`](../../../src/RequestHandlers/Api/HistoryView.php#L51-L58)
 
 Returns `void`
 
 **Throws:** `DependencyException`, `TableException`, `CacheException`
 
-#### [`getPrimaryCacheKey`](../../../src/RequestHandlers/Api/HistoryView.php#L60-L63)
+#### [`getPrimaryCacheKey`](../../../src/RequestHandlers/Api/HistoryView.php#L61-L64)
 
 Returns `string`
 
 **Attributes:** `#[Override]`
 
-#### [`handle`](../../../src/RequestHandlers/Api/HistoryView.php#L79-L112)
+#### [`handle`](../../../src/RequestHandlers/Api/HistoryView.php#L80-L115)
 
 Returns `Psr\Http\Message\ResponseInterface`
 

--- a/src/RequestHandlers/Api/HistoryView.php
+++ b/src/RequestHandlers/Api/HistoryView.php
@@ -21,6 +21,7 @@ use FediE2EE\PKDServer\Exceptions\{
 use FediE2EE\PKDServer\Interfaces\HttpCacheInterface;
 use FediE2EE\PKDServer\Tables\MerkleState;
 use JsonException as BaseJsonException;
+use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\HPKE\HPKEException;
 use Psr\SimpleCache\InvalidArgumentException;
 use SodiumException;
@@ -96,6 +97,8 @@ class HistoryView implements RequestHandlerInterface, HttpCacheInterface
                 return [
                     '!pkd-context' => 'fedi-e2ee:v1/api/history/view',
                     'created' => $leaf->created,
+                    'dir-publickeyhash' => Base64UrlSafe::encodeUnpadded(sodium_bin2hex($leaf->publicKeyhash)),
+                    'dir-signature' => Base64UrlSafe::encodeUnpadded(sodium_bin2hex($leaf->signature)),
                     'encrypted-message' => $leaf->contents,
                     'inclusion-proof' => $leaf->inclusionProof,
                     'message' => $message,

--- a/src/RequestHandlers/Api/HistoryView.php
+++ b/src/RequestHandlers/Api/HistoryView.php
@@ -97,7 +97,7 @@ class HistoryView implements RequestHandlerInterface, HttpCacheInterface
                 return [
                     '!pkd-context' => 'fedi-e2ee:v1/api/history/view',
                     'created' => $leaf->created,
-                    'dir-publickeyhash' => Base64UrlSafe::encodeUnpadded(sodium_bin2hex($leaf->publicKeyhash)),
+                    'dir-publickeyhash' => Base64UrlSafe::encodeUnpadded(sodium_bin2hex($leaf->publicKeyHash)),
                     'dir-signature' => Base64UrlSafe::encodeUnpadded(sodium_bin2hex($leaf->signature)),
                     'encrypted-message' => $leaf->contents,
                     'inclusion-proof' => $leaf->inclusionProof,


### PR DESCRIPTION
https://github.com/fedi-e2ee/public-key-directory-specification/pull/115

Decided to add this info to the "view hash" request not just "hashes since" requests.

The name is prefixed with `dir-` here to disambiguate with the message signature (which is client-side-generated).